### PR TITLE
[DSI-7793] A Express middleware for removing cookie `expires` and `max-age` properties

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,11 @@
 const asyncWrapper = require("./asyncWrapper");
 const getErrorHandler = require("./getErrorHandler");
 const ejsErrorPages = require("./ejsErrorPages");
+const setCookiesAsTransient = require("./setCookiesAsTransient");
 
 module.exports = {
   asyncWrapper,
   getErrorHandler,
   ejsErrorPages,
+  setCookiesAsTransient,
 };

--- a/lib/setCookiesAsTransient.js
+++ b/lib/setCookiesAsTransient.js
@@ -1,0 +1,59 @@
+/**
+ * @typedef {Object} TransientCookieOptions
+ * @property {RegExp[]} pattern - Regex patterns to match cookie names.
+ * @property {(req, res, next?) => void | Promise<void>} handler
+ */
+
+/**
+ * Creates an Express middleware that removes `expires` and `max-age`
+ * attributes from selected cookies, making them transient (session‑only).
+ *
+ * @param {TransientCookieOptions} options
+ * @returns {Function} Express-style middleware.
+ *
+ * @example
+ * const { setCookiesAsTransient } = require("login.dfe.express-error-handling");
+ * app.use(setCookiesAsTransient({
+ *   pattern: [/\.sig$/],
+ *   handler: your-handler-here,
+ * }));
+ */
+function setCookiesAsTransient(options) {
+  /**
+   * Does the cookie name match *any* supplied regex?
+   * Accepts a full Set‑Cookie string, extracts the name (text before “=”),
+   * and tests against each pattern.
+   */
+  const match = (cookie) => {
+    const name = cookie.split("=")[0];
+    return options.pattern.some((regExPattern) => regExPattern.test(name));
+  };
+
+  /**
+   * Returned middleware
+   */
+  return function (req, res, next) {
+    const originalWriteHead = res.writeHead;
+
+    res.writeHead = function (...args) {
+      const cookies = res.getHeader("set-cookie") || [];
+
+      const modifiedCookies = cookies.map((cookie) => {
+        const isExpired = /;\s*expires=Thu, 01 Jan 1970/i.test(cookie);
+        if (match(cookie) && !isExpired) {
+          return cookie
+            .replace(/;\s*expires=[^;]+/gi, "")
+            .replace(/;\s*max-age=[^;]+/gi, "");
+        }
+        return cookie;
+      });
+
+      res.setHeader("set-cookie", modifiedCookies);
+      return originalWriteHead.apply(res, args);
+    };
+
+    options.handler(req, res, next);
+  };
+}
+
+module.exports = setCookiesAsTransient;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "login.dfe.express-error-handling",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "login.dfe.express-error-handling",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "MIT",
       "dependencies": {
         "ejs": "^3.1.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1483,11 +1483,10 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha1-HtxFng8MVISG7Pn8mfIiE2S5oK4=",
+      "version": "2.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha1-VPxTI3phPYVMe9N0Y6rRffhyFOc=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -1851,9 +1850,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2968,9 +2967,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha1-VPxTI3phPYVMe9N0Y6rRffhyFOc=",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.express-error-handling",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Error handling middleware for express applications",
   "main": "lib/index.js",
   "scripts": {

--- a/test/setCookiesAsTransient.test.ts
+++ b/test/setCookiesAsTransient.test.ts
@@ -1,0 +1,113 @@
+const http = require("http");
+const setCookiesAsTransient = require("../lib/setCookiesAsTransient");
+
+describe("setCookiesAsTransient", () => {
+  let req, res, next, calledNext, cookiesSet;
+
+  beforeEach(() => {
+    req = new http.IncomingMessage();
+    res = new http.ServerResponse(req);
+
+    cookiesSet = [];
+    res.getHeader = jest.fn(() => cookiesSet);
+    res.setHeader = jest.fn((name, value) => {
+      if (name.toLowerCase() === "set-cookie") {
+        cookiesSet = value;
+      }
+    });
+
+    res.writeHead = jest.fn(function (...args) {
+      return this;
+    });
+
+    calledNext = false;
+    next = () => {
+      calledNext = true;
+    };
+  });
+
+  describe("when cookie names match the provided patterns", () => {
+    it("then removes `expires` and `max-age` attributes", () => {
+      cookiesSet = [
+        "_dsi_session.sig=xyz; Expires=Wed, 01 Jan 2025 00:00:00 GMT; Max-Age=3600",
+        "something.sig.foo=abc; Expires=Wed, 01 Jan 2025 00:00:00 GMT",
+        "session=abc; Expires=Wed, 01 Jan 2025 00:00:00 GMT",
+      ];
+
+      const middleware = setCookiesAsTransient({
+        pattern: [/\.sig$/],
+        handler: (req, res, next) => res.writeHead(200),
+      });
+
+      middleware(req, res, next);
+
+      const modifiedCookies = cookiesSet;
+
+      expect(modifiedCookies[0]).not.toMatch(/expires/i);
+      expect(modifiedCookies[0]).not.toMatch(/max-age/i);
+      expect(modifiedCookies[1]).toMatch(/expires/i);
+      expect(cookiesSet[2]).toMatch(/expires/i);
+    });
+  });
+
+  describe("when cookie names do not match any pattern", () => {
+    it("then leaves the cookies unchanged", () => {
+      cookiesSet = [
+        "_dsi_session.sig=xyz; Expires=Wed, 01 Jan 2025 00:00:00 GMT; Max-Age=3600",
+        "OTHER=abc; Expires=Wed, 01 Jan 2025 00:00:00 GMT",
+      ];
+
+      const middleware = setCookiesAsTransient({
+        pattern: [/^SID_/],
+        handler: (req, res, next) => res.writeHead(200),
+      });
+
+      middleware(req, res, next);
+
+      const modifiedCookies = cookiesSet;
+
+      expect(modifiedCookies[0]).toMatch(/expires/i);
+      expect(modifiedCookies[0]).toMatch(/max-age/i);
+      expect(modifiedCookies[1]).toMatch(/expires/i);
+    });
+  });
+
+  describe("when a cookie is already expired", () => {
+    it("then does not modify it", () => {
+      cookiesSet = [
+        "_dsi_session.sig=deleted; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0",
+      ];
+
+      const middleware = setCookiesAsTransient({
+        pattern: [/\.sig$/],
+        handler: (req, res, next) => res.writeHead(200),
+      });
+
+      middleware(req, res, next);
+
+      const modifiedCookies = cookiesSet;
+
+      expect(modifiedCookies[0]).toMatch(/expires/i);
+      expect(modifiedCookies[0]).toMatch(/max-age/i);
+    });
+  });
+
+  describe("when the middleware handler is executed", () => {
+    it("then calls the handler and `next`", () => {
+      const handler = jest.fn((req, res, next) => {
+        res.writeHead(200);
+        next();
+      });
+
+      const middleware = setCookiesAsTransient({
+        pattern: [/\.sig$/],
+        handler,
+      });
+
+      middleware(req, res, next);
+
+      expect(handler).toHaveBeenCalled();
+      expect(calledNext).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
### Summary
Jira ticket https://dfe-secureaccess.atlassian.net/browse/DSI-7793

Associated work
- login.dfe.oidc https://github.com/DFE-Digital/login.dfe.oidc/pull/282

### Changes

- Added `setCookiesAsTransient` which is an express middleware which can be configured with an array of regexes to test and match the cookie name, and remove the `expires` and `max-age` attributes.  In effect this changes the cookie from being persisted into a transient cookie.
- Added unit tests for `setCookiesAsTransient`
- Fixed 1 low npm vulnerability with `npm audit fix` 
